### PR TITLE
Re-enabled static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,11 @@ set(VERIFYTAPN_OSX_DEPLOYMENT_TARGET 10.8 CACHE STRING "Specify the minimum vers
 ## Configure Static
 if (VERIFYTAPN_Static)
     set(BUILD_SHARED_LIBS OFF)
-    #It seems linking -static does not work
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-    #if (NOT APPLE)
-    #    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-    #else () 
-    #    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-    #endif()
+    if (NOT APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    else () 
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    endif()
 endif ()
 
 ## Configure Traget Platform 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,8 @@ add_subdirectory(Core)
 add_subdirectory(ReachabilityChecker)
 
 add_executable(verifytapn-${ARCH_TYPE} main.cpp)
-target_link_libraries(verifytapn-${ARCH_TYPE} 
+target_link_libraries(verifytapn-${ARCH_TYPE} PRIVATE
 	Core 
 	ReachabilityChecker
-        libdbm.a libbase.a libudebug.a libhash.a
+        -ldbm -lbase -ludebug -lhash
 )


### PR DESCRIPTION
The way dbmlib was linked made cmake insert -Wl,-Bdynamic making the
-static flag not work as intended. By including dbm using -lXXX insted
this seems to have solved the issue